### PR TITLE
Create traffic selector variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ For static routing, please use the following variables:
 |------|-------------|:----:|:-----:|:-----:|
 | route_priority | The priority for static routes being added to VPC | int | 1000 | no |
 | remote_subnet | List of IP ranges that will be accessible over this VPN gateway. A route is created for each range in this list with next hop as VPN tunnels | list | - | yes |
+| local_traffic_selector | Local traffic selector to use when establishing the VPN tunnel with peer VPN gateway. Value should be list of CIDR formatted strings and ranges should be disjoint | list | ["0.0.0.0/0"] | no |
+| remote_traffic_selector | Remote traffic selector to use when establishing the VPN tunnel with peer VPN gateway. Value should be list of CIDR formatted strings and ranges should be disjoint | list | ["0.0.0.0/0"] | no |
 
 ## Outputs
 Please refer the /outputs.tf file for the outputs that you can get with the `terraform output` command

--- a/tunnel.tf
+++ b/tunnel.tf
@@ -28,8 +28,8 @@ resource "google_compute_vpn_tunnel" "tunnel-static" {
   shared_secret = "${local.default_shared_secret}"
 
   target_vpn_gateway      = "${google_compute_vpn_gateway.vpn_gateway.self_link}"
-  local_traffic_selector  = ["0.0.0.0/0"]
-  remote_traffic_selector = ["0.0.0.0/0"]
+  local_traffic_selector  = "${var.local_traffic_selector}"
+  remote_traffic_selector = "${var.remote_traffic_selector}"
 
   ike_version = "${var.ike_version}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,18 @@ variable "tunnel_name_prefix" {
   default     = ""
 }
 
+variable "local_traffic_selector" {
+  description = "The optional list of local traffic IP ranges"
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "remote_traffic_selector" {
+  description = "The optional list of remote traffic IP ranges"
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+}
+
 variable "peer_ips" {
   type        = "list"
   description = "IP address of remote-peer/gateway"


### PR DESCRIPTION
Added variables for `local_traffic_selector` and `remote_traffic_selector` lists so they may be user specified.

We use a Meraki MX60 router which only supports IKEv1 and requires that we have matching subnet definitions on the tunnel.

If you guys are interested in adding this then I can extend the readme if you would like.