### PR TITLE
Add boilerplate files from terraform-google-module-template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.3.0]
 ### CHANGED
-- Made `local_traffic_selector` and `remote_traffic_selector` configurable. 
+- Made `local_traffic_selector` and `remote_traffic_selector` configurable.
 - Update examples to use registry with versions
 - Reorganize README
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,146 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Please note that this file was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
+# Please make sure to contribute relevant changes upstream!
+
+# Make will use bash instead of sh
+SHELL := /usr/bin/env bash
+
+# Docker build config variables
+CREDENTIALS_PATH 			?= /cft/workdir/credentials.json
+DOCKER_ORG 				:= gcr.io/cloud-foundation-cicd
+DOCKER_TAG_BASE_KITCHEN_TERRAFORM 	?= 0.11.10_216.0.0_1.19.1_0.1.10
+DOCKER_REPO_BASE_KITCHEN_TERRAFORM 	:= ${DOCKER_ORG}/cft/kitchen-terraform:${DOCKER_TAG_BASE_KITCHEN_TERRAFORM}
+
+# All is the first target in the file so it will get picked up when you just run 'make' on its own
+all: check generate_docs
+
+# Run all available linters
+check: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace
+
+# The .PHONY directive tells make that this isn't a real target and so
+# the presence of a file named 'check_shell' won't cause this target to stop
+# working
+.PHONY: check_shell
+check_shell:
+	@source test/make.sh && check_shell
+
+.PHONY: check_python
+check_python:
+	@source test/make.sh && check_python
+
+.PHONY: check_golang
+check_golang:
+	@source test/make.sh && golang
+
+.PHONY: check_terraform
+check_terraform:
+	@source test/make.sh && check_terraform
+
+.PHONY: check_docker
+check_docker:
+	@source test/make.sh && docker
+
+.PHONY: check_base_files
+check_base_files:
+	@source test/make.sh && basefiles
+
+.PHONY: check_trailing_whitespace
+check_trailing_whitespace:
+	@source test/make.sh && check_trailing_whitespace
+
+.PHONY: test_check_headers
+test_check_headers:
+	@echo "Testing the validity of the header check"
+	@python test/test_verify_boilerplate.py
+
+.PHONY: check_headers
+check_headers:
+	@source test/make.sh && check_headers
+
+# Integration tests
+.PHONY: test_integration
+test_integration:
+	test/ci_integration.sh
+
+.PHONY: generate_docs
+generate_docs:
+	@source test/make.sh && generate_docs
+
+# Versioning
+.PHONY: version
+version:
+	@source helpers/version-repo.sh
+
+# Run docker
+.PHONY: docker_run
+docker_run:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
+		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-v $(CURDIR):/cft/workdir \
+		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && exec /bin/bash"
+
+.PHONY: docker_create
+docker_create:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
+		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-v $(CURDIR):/cft/workdir \
+		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen create"
+
+.PHONY: docker_converge
+docker_converge:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
+		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-v $(CURDIR):/cft/workdir \
+		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen converge"
+
+.PHONY: docker_verify
+docker_verify:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
+		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-v $(CURDIR):/cft/workdir \
+		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen verify"
+
+.PHONY: docker_destroy
+docker_destroy:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
+		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-v $(CURDIR):/cft/workdir \
+		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen destroy"
+
+.PHONY: test_integration_docker
+test_integration_docker:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
+		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-v $(CURDIR):/cft/workdir \
+		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
+		make test_integration

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "vpn-module-dynamic" {
   network                  = "${var.network}"
   region                   = "us-west1"
   gateway_name             = "vpn-gw-us-we1-dynamic"
-  tunnel_name_prefix       = "vpn-tn-us-we1-dynamic"  
+  tunnel_name_prefix       = "vpn-tn-us-we1-dynamic"
   shared_secret            = "secrets"
   tunnel_count             = 2
   peer_ips                 = ["1.1.1.1","2.2.2.2"]
@@ -84,9 +84,9 @@ Depending on if the VPN tunnel(s) will be using dynamic or static routing, diffe
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | cr_name | Name of cloud router that is being used | string | - | yes |
-| bgp_cr_session_range | Source IP and range of cloud router BGP session. List of IP and ranges to use, needs an IP/range for each tunnel in tunnel_count. First IP/range is used for BGP session of tunnel #1, second IP/range is used for BGP session of tunnel #2, and so on | list | - | yes | 
-| bgp_remote_session_range | Remote peer IP of cloud router BGP session. List of IP's to use, needs an IP/range for each tunnel in tunnel_count. First IP/range is used for BGP session of tunnel #1, second IP/range is used for BGP session of tunnel #2, and so on | list | - | yes | 
-| peer_asn | ASN number of peer for cloud router BGP session. List of ASN's to use, needs an ASN for each tunnel in tunnel_count. First ASN is used for BGP session of tunnel #1, second ASN is used for BGP session of tunnel #2, and so on | list | - | yes | 
+| bgp_cr_session_range | Source IP and range of cloud router BGP session. List of IP and ranges to use, needs an IP/range for each tunnel in tunnel_count. First IP/range is used for BGP session of tunnel #1, second IP/range is used for BGP session of tunnel #2, and so on | list | - | yes |
+| bgp_remote_session_range | Remote peer IP of cloud router BGP session. List of IP's to use, needs an IP/range for each tunnel in tunnel_count. First IP/range is used for BGP session of tunnel #1, second IP/range is used for BGP session of tunnel #2, and so on | list | - | yes |
+| peer_asn | ASN number of peer for cloud router BGP session. List of ASN's to use, needs an ASN for each tunnel in tunnel_count. First ASN is used for BGP session of tunnel #1, second ASN is used for BGP session of tunnel #2, and so on | list | - | yes |
 | advertised_route_priority | The priority of routes advertised to the BGP peers | int | 100 | no |
 
 
@@ -121,7 +121,7 @@ The project has the following folders and files:
 
 - /: root folder
 - /examples: examples for using this module
-- /main.tf: main file for this module, contains the routing resources 
+- /main.tf: main file for this module, contains the routing resources
 - /gateway.tf: contains the gateway resources
 - /tunnel.tf: contains the tunnel resources
 - /forwarding-rule.tf: contains the forwarding rules

--- a/helpers/combine_docfiles.py
+++ b/helpers/combine_docfiles.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Please note that this file was generated from
+# [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
+# Please make sure to contribute relevant changes upstream!
+
+''' Combine file from:
+  * script argument 1
+  with content of file from:
+  * script argument 2
+  using the beginning of line separators
+  hardcoded using regexes in this file:
+
+  We exclude any text using the separate
+  regex specified here
+'''
+
+import os
+import re
+import sys
+
+insert_separator_regex = r'(.*?\[\^\]\:\ \(autogen_docs_start\))(.*?)(\n\[\^\]\:\ \(autogen_docs_end\).*?$)'  # noqa: E501
+exclude_separator_regex = r'(.*?)Copyright 20\d\d Google LLC.*?limitations under the License.(.*?)$'  # noqa: E501
+
+if len(sys.argv) != 3:
+    sys.exit(1)
+
+if not os.path.isfile(sys.argv[1]):
+    sys.exit(0)
+
+input = open(sys.argv[1], "r").read()
+replace_content = open(sys.argv[2], "r").read()
+
+# Exclude the specified content from the replacement content
+groups = re.match(
+    exclude_separator_regex,
+    replace_content,
+    re.DOTALL
+).groups(0)
+replace_content = groups[0] + groups[1]
+
+# Find where to put the replacement content, overwrite the input file
+groups = re.match(insert_separator_regex, input, re.DOTALL).groups(0)
+output = groups[0] + replace_content + groups[2] + "\n"
+open(sys.argv[1], "w").write(output)

--- a/test/make.sh
+++ b/test/make.sh
@@ -14,83 +14,144 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This function checks to make sure that every
-# shebang has a '- e' flag, which causes it
-# to exit on error
-function check_bash() {
-find . -name "*.sh" | while IFS= read -d '' -r file;
-do
-  if [[ "$file" != *"bash -e"* ]];
-  then
-    echo "$file is missing shebang with -e";
-    exit 1;
-  fi;
-done;
+# Please note that this file was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
+# Please make sure to contribute relevant changes upstream!
+
+# Create a temporary directory that's auto-cleaned, even if the process aborts.
+DELETE_AT_EXIT="$(mktemp -d)"
+finish() {
+  [[ -d "${DELETE_AT_EXIT}" ]] && rm -rf "${DELETE_AT_EXIT}"
+}
+trap finish EXIT
+# Create a temporary file in the auto-cleaned up directory while avoiding
+# overwriting TMPDIR for other processes.
+# shellcheck disable=SC2120 # (Arguments may be passed, e.g. maketemp -d)
+maketemp() {
+  TMPDIR="${DELETE_AT_EXIT}" mktemp "$@"
+}
+
+# find_files is a helper to exclude .git directories and match only regular
+# files to avoid double-processing symlinks.
+find_files() {
+  local pth="$1"
+  shift
+  find "${pth}" '(' -path '*/.git' -o -path '*/.terraform' ')' \
+    -prune -o -type f "$@"
+}
+
+# Compatibility with both GNU and BSD style xargs.
+compat_xargs() {
+  local compat=()
+  # Test if xargs is GNU or BSD style.  GNU xargs will succeed with status 0
+  # when given --no-run-if-empty and no input on STDIN.  BSD xargs will fail and
+  # exit status non-zero If xargs fails, assume it is BSD style and proceed.
+  # stderr is silently redirected to avoid console log spam.
+  if xargs --no-run-if-empty </dev/null 2>/dev/null; then
+    compat=("--no-run-if-empty")
+  fi
+  xargs "${compat[@]}" "$@"
 }
 
 # This function makes sure that the required files for
 # releasing to OSS are present
 function basefiles() {
-  echo "Checking for required files"
-  test -f LICENSE || echo "Missing LICENSE"
-  test -f README.md || echo "Missing README.md"
+  local fn required_files="LICENSE README.md"
+  echo "Checking for required files ${required_files}"
+  for fn in ${required_files}; do
+    test -f "${fn}" || echo "Missing required file ${fn}"
+  done
 }
 
 # This function runs the hadolint linter on
 # every file named 'Dockerfile'
 function docker() {
   echo "Running hadolint on Dockerfiles"
-  find . -name "Dockerfile" -exec hadolint {} \;
+  find_files . -name "Dockerfile" -print0 \
+    | compat_xargs -0 hadolint
 }
 
 # This function runs 'terraform validate' against all
-# files ending in '.tf'
+# directory paths which contain *.tf files.
 function check_terraform() {
   echo "Running terraform validate"
-  #shellcheck disable=SC2156
-  find . -name "*.tf" -exec bash -c 'terraform validate --check-variables=false $(dirname "{}")' \;
+  find_files . -name "*.tf" -print0 \
+    | compat_xargs -0 -n1 dirname \
+    | sort -u \
+    | grep -xv './test/fixtures/shared' \
+    | compat_xargs -t -n1 terraform validate --check-variables=false
 }
 
-# This function runs 'go fmt' and 'go vet' on eery file
+# This function runs 'go fmt' and 'go vet' on every file
 # that ends in '.go'
 function golang() {
   echo "Running go fmt and go vet"
-  find . -name "*.go" -exec go fmt {} \;
-  find . -name "*.go" -exec go vet {} \;
+  find_files . -name "*.go" -print0 | compat_xargs -0 -n1 go fmt
+  find_files . -name "*.go" -print0 | compat_xargs -0 -n1 go vet
 }
 
 # This function runs the flake8 linter on every file
 # ending in '.py'
 function check_python() {
   echo "Running flake8"
-  find . -name "*.py" -exec flake8 {} \;
+  find_files . -name "*.py" -print0 | compat_xargs -0 flake8
+  return 0
 }
 
 # This function runs the shellcheck linter on every
 # file ending in '.sh'
 function check_shell() {
   echo "Running shellcheck"
-  find . -name "*.sh" -exec shellcheck -x {} \;
+  find_files . -name "*.sh" -print0 | compat_xargs -0 shellcheck -x
 }
 
 # This function makes sure that there is no trailing whitespace
 # in any files in the project.
 # There are some exclusions
 function check_trailing_whitespace() {
-  echo "The following lines have trailing whitespace"
-  grep -r '[[:blank:]]$' --exclude-dir=".terraform" --exclude="*.png" --exclude="*.pyc" --exclude-dir=".git" .
+  local rc
+  echo "Checking for trailing whitespace"
+  find_files . -print \
+    | grep -v -E '\.(pyc|png)$' \
+    | compat_xargs grep -H -n '[[:blank:]]$'
   rc=$?
-  if [ $rc = 0 ]; then
-    exit 1
+  if [[ ${rc} -eq 0 ]]; then
+    return 1
   fi
 }
 
 function generate_docs() {
   echo "Generating markdown docs with terraform-docs"
-  TMPFILE=$(mktemp)
-  for j in `for i in $(find . -type f | grep \.tf$) ; do dirname $i ; done | sort -u` ; do
-    terraform-docs markdown $j > $TMPFILE
-    python helpers/combine_docfiles.py $j/README.md $TMPFILE
+  local path tmpfile
+  while read -r path; do
+    if [[ -e "${path}/README.md" ]]; then
+      # shellcheck disable=SC2119
+      tmpfile="$(maketemp)"
+      echo "terraform-docs markdown ${path}"
+      terraform-docs markdown "${path}" > "${tmpfile}"
+      helpers/combine_docfiles.py "${path}"/README.md "${tmpfile}"
+    else
+      echo "Skipping ${path} because README.md does not exist."
+    fi
+  done < <(find_files . -name '*.tf' -print0 \
+    | compat_xargs -0 -n1 dirname \
+    | sort -u)
+}
+
+function prepare_test_variables() {
+  echo "Preparing terraform.tfvars files for integration tests"
+  #shellcheck disable=2044
+  for i in $(find ./test/fixtures -type f -name terraform.tfvars.sample); do
+    destination=${i/%.sample/}
+    if [ ! -f "${destination}" ]; then
+      cp "${i}" "${destination}"
+      echo "${destination} has been created. Please edit it to reflect your GCP configuration."
+    fi
   done
-  rm -f $TMPFILE
+}
+
+function check_headers() {
+  echo "Checking file headers"
+  # Use the exclusion behavior of find_files
+  find_files . -type f -print0 \
+    | compat_xargs -0 python test/verify_boilerplate.py
 }

--- a/tunnel.tf
+++ b/tunnel.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-# Creating the VPN tunnel 
+# Creating the VPN tunnel
 resource "random_id" "ipsec_secret" {
   byte_length = 8
 }


### PR DESCRIPTION
This commit adds the standard boilerplate for running lint checks against the module. The addition of these files means that we'll be able to run CI against this module to ensure that changes meet our quality requirements.