### PR TITLE
Add integration test scaffolding

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,34 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+platforms:
+  - name: terraform
+
+provisioner:
+  name: terraform
+
+suites:
+  - name: single_tunnels
+    driver:
+      name: terraform
+      root_module_directory: test/fixtures/single_tunnels
+      command_timeout: 1800
+    verifier:
+      name: terraform
+      color: false
+      systems:
+        - name: gcp
+          backend: gcp
+          controls:
+            - gcp

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ version:
 .PHONY: docker_run
 docker_run:
 	docker run --rm -it \
+		-e PROD_PROJECT_ID \
+		-e PROD_NETWORK \
+		-e MGT_PROJECT_ID \
+		-e MGT_NETWORK \
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
@@ -98,6 +102,10 @@ docker_run:
 .PHONY: docker_create
 docker_create:
 	docker run --rm -it \
+		-e PROD_PROJECT_ID \
+		-e PROD_NETWORK \
+		-e MGT_PROJECT_ID \
+		-e MGT_NETWORK \
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
@@ -108,6 +116,10 @@ docker_create:
 .PHONY: docker_converge
 docker_converge:
 	docker run --rm -it \
+		-e PROD_PROJECT_ID \
+		-e PROD_NETWORK \
+		-e MGT_PROJECT_ID \
+		-e MGT_NETWORK \
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
@@ -118,6 +130,10 @@ docker_converge:
 .PHONY: docker_verify
 docker_verify:
 	docker run --rm -it \
+		-e PROD_PROJECT_ID \
+		-e PROD_NETWORK \
+		-e MGT_PROJECT_ID \
+		-e MGT_NETWORK \
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
@@ -128,6 +144,10 @@ docker_verify:
 .PHONY: docker_destroy
 docker_destroy:
 	docker run --rm -it \
+		-e PROD_PROJECT_ID \
+		-e PROD_NETWORK \
+		-e MGT_PROJECT_ID \
+		-e MGT_NETWORK \
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
@@ -138,6 +158,10 @@ docker_destroy:
 .PHONY: test_integration_docker
 test_integration_docker:
 	docker run --rm -it \
+		-e PROD_PROJECT_ID \
+		-e PROD_NETWORK \
+		-e MGT_PROJECT_ID \
+		-e MGT_NETWORK \
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Always clean up.
+DELETE_AT_EXIT="$(mktemp -d)"
+finish() {
+  echo 'BEGIN: finish() trap handler' >&2
+  kitchen destroy "$SUITE"
+  [[ -d "${DELETE_AT_EXIT}" ]] && rm -rf "${DELETE_AT_EXIT}"
+  echo 'END: finish() trap handler' >&2
+}
+
+# Map the input parameters provided by Concourse CI, or whatever mechanism is
+# running the tests to Terraform input variables.  Also setup credentials for
+# use with kitchen-terraform, inspec, and gcloud.
+setup_environment() {
+  local tmpfile
+  tmpfile="$(mktemp)"
+  echo "${SERVICE_ACCOUNT_JSON}" > "${tmpfile}"
+
+  # gcloud variables
+  export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="${tmpfile}"
+  # Application default credentials (Terraform google provider and inspec-gcp)
+  export GOOGLE_APPLICATION_CREDENTIALS="${tmpfile}"
+
+  # Terraform  variables
+  export TF_VAR_prod_project_id="${PROD_PROJECT_ID}"
+  export TF_VAR_prod_network="${PROD_NETWORK}"
+  export TF_VAR_mgt_project_id="${MGT_PROJECT_ID}"
+  export TF_VAR_mgt_network="${MGT_NETWORK}"
+}
+
+main() {
+  export SUITE="${SUITE:-}"
+
+  set -eu
+  # Setup trap handler to auto-cleanup
+  export TMPDIR="${DELETE_AT_EXIT}"
+  trap finish EXIT
+
+  # Setup environment variables
+  setup_environment
+  set -x
+
+  # Execute the test lifecycle
+  kitchen create "$SUITE"
+  kitchen converge "$SUITE"
+  kitchen verify "$SUITE"
+}
+
+# if script is being executed and not sourced.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/test/fixtures/single_tunnels/main.tf
+++ b/test/fixtures/single_tunnels/main.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "single_tunnels" {
+  source = "../../../examples/single_tunnels"
+}

--- a/test/integration/single_tunnels/controls/gcp.rb
+++ b/test/integration/single_tunnels/controls/gcp.rb
@@ -1,0 +1,13 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/integration/single_tunnels/inspec.yml
+++ b/test/integration/single_tunnels/inspec.yml
@@ -1,0 +1,5 @@
+name: single_tunnels
+depends:
+  - name: inspec-gcp
+    git: https://github.com/inspec/inspec-gcp.git
+    version: '~> 0.9.0'


### PR DESCRIPTION
This commit adds the necessary scripts and configuration files to add kitchen-terraform integration tests. The addition of these files gives us the foundation to start spinning up test fixtures and verifying them, but defers the implementation of the fixtures and tests to a later commit.