### PR TITLE
Add the project argument to external_gateway

### DIFF
--- a/modules/vpn_ha/main.tf
+++ b/modules/vpn_ha/main.tf
@@ -42,6 +42,7 @@ resource "google_compute_external_vpn_gateway" "external_gateway" {
   provider        = google-beta
   count           = var.peer_external_gateway != null ? 1 : 0
   name            = "external-${var.name}"
+  project         = var.project_id
   redundancy_type = var.peer_external_gateway.redundancy_type
   description     = "Terraform managed external VPN gateway"
   dynamic "interface" {


### PR DESCRIPTION
This allows the module to run without a default project configured in the provider.
And it's consistent with the other resources, which do specify a project argument.

(By the way, thanks for making this module!)