### PR TITLE
ha_vpn: Use external "URL" for source in the README

### DIFF
--- a/modules/vpn_ha/README.md
+++ b/modules/vpn_ha/README.md
@@ -83,7 +83,7 @@ module "vpn_ha-2" {
 
 ```hcl
 module "vpn_ha" {
-  source = "../modules/net-vpn-ha"
+  source = "terraform-google-modules/vpn/google//modules/vpn_ha"
   project_id  = "<PROJECT_ID>"
   region  = "europe-west4"
   network         = "https://www.googleapis.com/compute/v1/projects/<PROJECT_ID>/global/networks/my-network"


### PR DESCRIPTION
Terraform recommends using an "external" URL for the source attribute in
a module in the README.

> Because examples will often be copied into other repositories for
> customization, any module blocks should have their source set to
> the address an external caller would use, not to a relative path.
-- https://www.terraform.io/docs/modules/index.html