### PR TITLE
Fix numeric indexes for tunnels and subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,13 +23,13 @@ locals {
 ## Create Route (for static routing gateways)
 resource "google_compute_route" "route" {
   count      = ! var.cr_enabled ? var.tunnel_count * length(var.remote_subnet) : 0
-  name       = "${google_compute_vpn_gateway.vpn_gateway.name}-tunnel${count.index % var.tunnel_count + 1}-route${count.index % length(var.remote_subnet) + 1}"
+  name       = "${google_compute_vpn_gateway.vpn_gateway.name}-tunnel${floor(count.index / length(var.remote_subnet)) + 1}-route${count.index % length(var.remote_subnet) + 1}"
   network    = var.network
   project    = var.project_id
   dest_range = var.remote_subnet[count.index % length(var.remote_subnet)]
   priority   = var.route_priority
 
-  next_hop_vpn_tunnel = google_compute_vpn_tunnel.tunnel-static[count.index % var.tunnel_count].self_link
+  next_hop_vpn_tunnel = google_compute_vpn_tunnel.tunnel-static[floor(count.index / length(var.remote_subnet))].self_link
 
   depends_on = [google_compute_vpn_tunnel.tunnel-static]
 }


### PR DESCRIPTION
This PR fixes compute route resource naming when tunnel_count is greater than 1.

Related issue:

Fixes #38.

To give more context what this PR is doing:

Originally, the module is trying to name and number the routes by tunnel number and subnet number, something like `gateway-route-1-2`, where `1` here is the tunnel number and `2` is the subnet number.

To do so, it first computes the total number of routes (#tunnels * #subnets), and then tries to divvy that number up and number them, but it does this part incorrectly.  In the old way, it was setting tunnel index to the index % # tunnels + 1, and subnet index to index % # subnets + 1, which if you have 2 tunnels and 2 subets, would lead to this result:

```
count = 2 tunnels * 2 subnets = 4

index | index % 2 (tunnels) + 1 | index % 2 (subnets) + 1
0     |                       1 |                       1
1     |                       2 |                       2
2     |                       1 |                       1
3     |                       2 |                       2
```

As you can see, you end up with duplicates.  The correct way to go about this (which is what Jonathan is doing here), is to do effectively long division by some divisor (either # tunnels or # subnets), where the whole number is one part, and the remainder is the other part.   So, in this code, he's choosing # subnets as the divisor, so, dividing by it for the tunnel index, and then modulo it for the subnet index.  Doing this gives the intended behavior:

```
count = 2 tunnels * 2 subnets = 4

index | floor(index / 2 (subnets)) + 1 | index % 2 (subnets) + 1
0     |                              1 |                       1
1     |                              1 |                       2
2     |                              2 |                       1
3     |                              2 |                       2
```

Another example:
```
count = 2 tunnels * 1 subnets = 2

index | floor(index / 1 (subnets)) + 1 | index % 1 (subnets) + 1
0     |                              1 |                       1
1     |                              2 |                       1
```

We're always dividing by number of subnets, so if it's just 1, then 0 / 1 = 0 + 1 = 1, and for the 2nd one, 1 / 1 = 1 + 1 = 2, while anything modulo 1 will always be 0, +1 = 1
