### PR TITLE
Fix for Terraform 0.14.0: Tunnels now considered sensitive

### DIFF
--- a/modules/vpn_ha/outputs.tf
+++ b/modules/vpn_ha/outputs.tf
@@ -50,6 +50,7 @@ output "self_link" {
 
 output "tunnels" {
   description = "VPN tunnel resources."
+  sensitive   = true
   value = {
     for name in keys(var.tunnels) :
     name => google_compute_vpn_tunnel.tunnels[name]
@@ -58,6 +59,7 @@ output "tunnels" {
 
 output "tunnel_names" {
   description = "VPN tunnel names."
+  sensitive   = true
   value = {
     for name in keys(var.tunnels) :
     name => google_compute_vpn_tunnel.tunnels[name].name
@@ -66,6 +68,7 @@ output "tunnel_names" {
 
 output "tunnel_self_links" {
   description = "VPN tunnel self links."
+  sensitive   = true
   value = {
     for name in keys(var.tunnels) :
     name => google_compute_vpn_tunnel.tunnels[name].self_link


### PR DESCRIPTION
During our upgrade to Terraform 0.14.0 and google provider to 3.52.0 we got errors that Tunnels output are considered sensitive but is not configured as such.

This PR adds the sensitive field to the Tunnel outputs to suppress this error.