### PR TITLE
fix: Terraform 14 sensitive values outputs reference

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ locals {
 # For VPN gateways with static routing
 ## Create Route (for static routing gateways)
 resource "google_compute_route" "route" {
-  count      = !var.cr_enabled ? var.tunnel_count * length(var.remote_subnet) : 0
+  count      = ! var.cr_enabled ? var.tunnel_count * length(var.remote_subnet) : 0
   name       = "${google_compute_vpn_gateway.vpn_gateway.name}-tunnel${floor(count.index / length(var.remote_subnet)) + 1}-route${count.index % length(var.remote_subnet) + 1}"
   network    = var.network
   project    = var.project_id

--- a/modules/vpn_ha/outputs.tf
+++ b/modules/vpn_ha/outputs.tf
@@ -50,6 +50,7 @@ output "self_link" {
 
 output "tunnels" {
   description = "VPN tunnel resources."
+  sensitive   = true
   value = {
     for name in keys(var.tunnels) :
     name => google_compute_vpn_tunnel.tunnels[name]
@@ -58,6 +59,7 @@ output "tunnels" {
 
 output "tunnel_names" {
   description = "VPN tunnel names."
+  sensitive   = true
   value = {
     for name in keys(var.tunnels) :
     name => google_compute_vpn_tunnel.tunnels[name].name
@@ -66,6 +68,7 @@ output "tunnel_names" {
 
 output "tunnel_self_links" {
   description = "VPN tunnel self links."
+  sensitive   = true
   value = {
     for name in keys(var.tunnels) :
     name => google_compute_vpn_tunnel.tunnels[name].self_link

--- a/tunnel.tf
+++ b/tunnel.tf
@@ -20,7 +20,7 @@ resource "random_id" "ipsec_secret" {
 }
 
 resource "google_compute_vpn_tunnel" "tunnel-static" {
-  count         = !var.cr_enabled ? var.tunnel_count : 0
+  count         = ! var.cr_enabled ? var.tunnel_count : 0
   name          = var.tunnel_count == 1 ? format("%s-%s", local.tunnel_name_prefix, "1") : format("%s-%d", local.tunnel_name_prefix, count.index + 1)
   region        = var.region
   project       = var.project_id


### PR DESCRIPTION
The [PR 46](https://github.com/terraform-google-modules/terraform-google-vpn/pull/46) did not have any activity since a while, but the issue is still present. Basically, starting with Terraform14 and Google provider 3.52.0, it complains that some fields need to be marked as sensitive.

Example of error:
```hcl
Error: Output refers to sensitive values

  on ../../modules/vpn_ha/outputs.tf line 35:
  35: output "tunnels" {

Expressions used in outputs can only refer to sensitive values if the
sensitive attribute is true.
```

Hopefully this PR will be reviewed and merged. Have also fixed some terraform format linting errors.