### PR TITLE
Update outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -52,6 +52,7 @@ output "vpn_tunnels_self_link-static" {
 output "ipsec_secret-static" {
   description = "The secret"
   value       = google_compute_vpn_tunnel.tunnel-static.*.shared_secret
+  sensitive = true
 }
 
 output "vpn_tunnels_names-dynamic" {


### PR DESCRIPTION
```
Error: Output refers to sensitive values
│ 
│   on outputs.tf line 52:
│   52: output "ipsec_secret-static" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
```