### PR TITLE
use random_password instead of random_id for secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   tunnel_name_prefix    = var.tunnel_name_prefix != "" ? var.tunnel_name_prefix : "${var.network}-${var.gateway_name}-tunnel"
-  default_shared_secret = var.shared_secret != "" ? var.shared_secret : random_id.ipsec_secret.b64_url
+  default_shared_secret = var.shared_secret != "" ? var.shared_secret : random_password.ipsec_secret[0].result
 }
 
 # For VPN gateways with static routing

--- a/modules/vpn_ha/main.tf
+++ b/modules/vpn_ha/main.tf
@@ -25,9 +25,7 @@ locals {
     var.peer_external_gateway != null
     ? google_compute_external_vpn_gateway.external_gateway[0].self_link
     : null
-
   )
-  secret = random_id.secret.b64_url
   vpn_gateway_self_link = (
     var.create_vpn_gateway
     ? google_compute_ha_vpn_gateway.ha_gateway[0].self_link
@@ -163,11 +161,12 @@ resource "google_compute_vpn_tunnel" "tunnels" {
   peer_gcp_gateway                = var.peer_gcp_gateway
   vpn_gateway_interface           = each.value.vpn_gateway_interface
   ike_version                     = each.value.ike_version
-  shared_secret                   = each.value.shared_secret == "" ? local.secret : each.value.shared_secret
+  shared_secret                   = each.value.shared_secret == "" ? random_password.secret.result : each.value.shared_secret
   vpn_gateway                     = local.vpn_gateway_self_link
   labels                          = var.labels
 }
 
-resource "random_id" "secret" {
-  byte_length = 8
+resource "random_password" "secret" {
+  length  = 32
+  special = false
 }

--- a/modules/vpn_ha/outputs.tf
+++ b/modules/vpn_ha/outputs.tf
@@ -78,5 +78,5 @@ output "tunnel_self_links" {
 output "random_secret" {
   description = "Generated secret."
   sensitive   = true
-  value       = local.secret
+  value       = random_password.secret.result
 }

--- a/tunnel.tf
+++ b/tunnel.tf
@@ -15,8 +15,10 @@
  */
 
 # Creating the VPN tunnel
-resource "random_id" "ipsec_secret" {
-  byte_length = 8
+resource "random_password" "ipsec_secret" {
+  count   = var.shared_secret == "" ? 1 : 0
+  length  = 32
+  special = false
 }
 
 resource "google_compute_vpn_tunnel" "tunnel-static" {


### PR DESCRIPTION
- random_id byte_length = 8 (integers) contains 26.6 bits of
  entropy. base64url encoding does not change that entropy.
  Instead use random_password length = 32 restricted to (upper,
  lower, int) which contains 190.5 bits of entropy.
- Restrict random_password to special = false to prevent issues
  with allowed characters.