### PR TITLE
Add ability to specify route priorities on aper-tunnel basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ References the variable descriptions below to determine the right configuration.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| advertised\_route\_priority | Please enter the priority for the advertised route to BGP peer(default is 100) | `number` | `100` | no |
+| advertised\_route\_priorities | Please enter the priorities for the advertised routes to BGP peer(default is 100 for each tunnel) | `list(number)` | <pre>[<br>  100,<br>  100<br>]</pre> | no |
 | bgp\_cr\_session\_range | Please enter the cloud-router interface IP/Session IP | `list(string)` | <pre>[<br>  "169.254.1.1/30",<br>  "169.254.1.5/30"<br>]</pre> | no |
 | bgp\_remote\_session\_range | Please enter the remote environments BGP Session IP | `list(string)` | <pre>[<br>  "169.254.1.2",<br>  "169.254.1.6"<br>]</pre> | no |
 | cr\_enabled | If there is a cloud router for BGP routing | `bool` | `false` | no |
@@ -104,7 +104,7 @@ References the variable descriptions below to determine the right configuration.
 | region | The region in which you want to create the VPN gateway | `string` | n/a | yes |
 | remote\_subnet | remote subnet ip range in CIDR format - x.x.x.x/x | `list(string)` | `[]` | no |
 | remote\_traffic\_selector | Remote traffic selector to use when establishing the VPN tunnel with peer VPN gateway.<br>Value should be list of CIDR formatted strings and ranges should be disjoint. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| route\_priority | Priority for static route being created | `number` | `1000` | no |
+| route\_priorities | Priorities for static routes being created | `list(number)` | <pre>[<br>  1000,<br>  1000<br>]</pre> | no |
 | route\_tags | A list of instance tags to which this route applies. | `list(string)` | `[]` | no |
 | shared\_secret | Please enter the shared secret/pre-shared key | `string` | `""` | no |
 | tunnel\_count | The number of tunnels from each VPN gw (default is 1) | `number` | `1` | no |

--- a/examples/multi_tunnels/mgmt.tf
+++ b/examples/multi_tunnels/mgmt.tf
@@ -84,7 +84,7 @@ module "vpn-gw-us-we1-mgt-prd-internal" {
   tunnel_count       = 1
   peer_ips           = [module.vpn-gw-us-we1-prd-mgt-internal.gateway_ip]
 
-  route_priority = 1000
+  route_priorities = [1000, 1000]
   remote_subnet  = ["10.17.0.0/22", "10.16.80.0/24"]
 }
 

--- a/examples/multi_tunnels/prod.tf
+++ b/examples/multi_tunnels/prod.tf
@@ -84,7 +84,7 @@ module "vpn-gw-us-we1-prd-mgt-internal" {
   tunnel_count       = 1
   peer_ips           = [module.vpn-gw-us-we1-mgt-prd-internal.gateway_ip]
 
-  route_priority = 1000
+  route_priorities = [1000, 1000]
   remote_subnet  = ["10.17.32.0/20", "10.17.16.0/20"]
 }
 

--- a/examples/single_tunnels/mgmt.tf
+++ b/examples/single_tunnels/mgmt.tf
@@ -55,6 +55,6 @@ module "vpn-gw-us-we1-mgt-prd-internal" {
   tunnel_count       = 1
   peer_ips           = [module.vpn-gw-us-we1-prd-mgt-internal.gateway_ip]
 
-  route_priority = 1000
+  route_priorities = [1000]
   remote_subnet  = ["10.17.0.0/22", "10.16.80.0/24"]
 }

--- a/examples/single_tunnels/prod.tf
+++ b/examples/single_tunnels/prod.tf
@@ -55,7 +55,7 @@ module "vpn-gw-us-we1-prd-mgt-internal" {
   tunnel_count       = 1
   peer_ips           = [module.vpn-gw-us-we1-mgt-prd-internal.gateway_ip]
 
-  route_priority = 1000
+  route_priorities = [1000]
   remote_subnet  = ["10.17.32.0/20", "10.17.16.0/20"]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "google_compute_route" "route" {
   network    = var.network
   project    = var.project_id
   dest_range = var.remote_subnet[count.index % length(var.remote_subnet)]
-  priority   = var.route_priority
+  priority   = var.route_priorities[count.index]
   tags       = var.route_tags
 
   next_hop_vpn_tunnel = google_compute_vpn_tunnel.tunnel-static[floor(count.index / length(var.remote_subnet))].self_link
@@ -57,7 +57,7 @@ resource "google_compute_router_peer" "bgp_peer" {
   region                    = var.region
   peer_ip_address           = var.bgp_remote_session_range[count.index]
   peer_asn                  = var.peer_asn[count.index]
-  advertised_route_priority = var.advertised_route_priority
+  advertised_route_priority = var.advertised_route_priorities[count.index]
   interface                 = "interface-${local.tunnel_name_prefix}-${count.index}"
   project                   = var.project_id
 

--- a/variables.tf
+++ b/variables.tf
@@ -86,9 +86,10 @@ variable "shared_secret" {
   default     = ""
 }
 
-variable "route_priority" {
-  description = "Priority for static route being created"
-  default     = 1000
+variable "route_priorities" {
+  type = list(number)
+  description = "Priorities for static routes being created"
+  default     = [1000, 1000]
 }
 
 variable "cr_name" {
@@ -121,9 +122,10 @@ variable "bgp_remote_session_range" {
   default     = ["169.254.1.2", "169.254.1.6"]
 }
 
-variable "advertised_route_priority" {
-  description = "Please enter the priority for the advertised route to BGP peer(default is 100)"
-  default     = 100
+variable "advertised_route_priorities" {
+  type = list(number)
+  description = "Please enter the priorities for the advertised routes to BGP peer(default is 100 for each tunnel)"
+  default     = [100, 100]
 }
 
 variable "ike_version" {


### PR DESCRIPTION
Sometimes it's useful to specify distinct route priorities for each individual tunnel, since sometimes we want to direct outbound traffic through a specific tunnel by default.