### PR TITLE
feat: refactor subnet logic for individual route priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,14 @@ module "vpn-prod-internal" {
   tunnel_count       = 1
   peer_ips           = ["1.1.1.1", "2.2.2.2"]
 
-  route_priority = 1000
-  remote_subnet  = ["10.17.0.0/22", "10.16.80.0/24"]
+  routes = [
+    {
+     remote_subnet = "10.17.0.0/22"
+    },
+    {
+     remote_subnet = "10.16.80.0/24"
+    }
+  ]
 }
 
 module "vpn-manage-internal" {
@@ -67,8 +73,16 @@ module "vpn-manage-internal" {
   tunnel_count       = 1
   peer_ips           = ["1.1.1.1", "2.2.2.2"]
 
-  route_priority = 1000
-  remote_subnet  = ["10.17.32.0/20", "10.17.16.0/20"]
+  routes = [
+    {
+     remote_subnet = "10.17.32.0/20"
+     priority = 1000
+    },
+    {
+     remote_subnet = "10.17.16.0/20"
+     priority = 1000
+    }
+  ]
 }
 ```
 
@@ -102,10 +116,8 @@ References the variable descriptions below to determine the right configuration.
 | peer\_ips | IP address of remote-peer/gateway | `list(string)` | n/a | yes |
 | project\_id | The ID of the project where this VPC will be created | `string` | n/a | yes |
 | region | The region in which you want to create the VPN gateway | `string` | n/a | yes |
-| remote\_subnet | remote subnet ip range in CIDR format - x.x.x.x/x | `list(string)` | `[]` | no |
 | remote\_traffic\_selector | Remote traffic selector to use when establishing the VPN tunnel with peer VPN gateway.<br>Value should be list of CIDR formatted strings and ranges should be disjoint. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| route\_priority | Priority for static route being created | `number` | `1000` | no |
-| route\_tags | A list of instance tags to which this route applies. | `list(string)` | `[]` | no |
+| routes | A list of routes. Each route has a remote_subnet ip range in CIDR format - x.x.x.x/x, a priority for the route being created, and a list of instance tags | `object({ remote_subnet=string, priority=number, tags=list(string) })` | <pre>[<br>  {<br>    remote_subnet = ""<br>    priority      = 1000<br>    tags          = []<br>  }<br>] | no
 | shared\_secret | Please enter the shared secret/pre-shared key | `string` | `""` | no |
 | tunnel\_count | The number of tunnels from each VPN gw (default is 1) | `number` | `1` | no |
 | tunnel\_name\_prefix | The optional custom name of VPN tunnel being created | `string` | `""` | no |

--- a/examples/multi_tunnels/mgmt.tf
+++ b/examples/multi_tunnels/mgmt.tf
@@ -83,8 +83,15 @@ module "vpn-gw-us-we1-mgt-prd-internal" {
   shared_secret      = "secrets"
   tunnel_count       = 1
   peer_ips           = [module.vpn-gw-us-we1-prd-mgt-internal.gateway_ip]
-
-  route_priority = 1000
-  remote_subnet  = ["10.17.0.0/22", "10.16.80.0/24"]
+  routes = [
+    {
+      remote_subnet = "10.17.0.0/22"
+      priority      = 1000
+    },
+    {
+      remote_subnet = "10.16.80.0/24"
+      priority      = 1000
+    }
+  ]
 }
 

--- a/examples/multi_tunnels/prod.tf
+++ b/examples/multi_tunnels/prod.tf
@@ -84,7 +84,15 @@ module "vpn-gw-us-we1-prd-mgt-internal" {
   tunnel_count       = 1
   peer_ips           = [module.vpn-gw-us-we1-mgt-prd-internal.gateway_ip]
 
-  route_priority = 1000
-  remote_subnet  = ["10.17.32.0/20", "10.17.16.0/20"]
+  routes = [
+    {
+      remote_subnet = "10.17.32.0/20"
+      priority      = 1000
+    },
+    {
+      remote_subnet = "10.17.16.0/20"
+      priority      = 1000
+    }
+  ]
 }
 

--- a/examples/single_tunnels/mgmt.tf
+++ b/examples/single_tunnels/mgmt.tf
@@ -25,6 +25,12 @@ module "vpn-gw-us-we1-mgt-prd-internal" {
   tunnel_count       = 1
   peer_ips           = [module.vpn-gw-us-we1-prd-mgt-internal.gateway_ip]
 
-  route_priority = 1000
-  remote_subnet  = ["10.17.0.0/22", "10.16.80.0/24"]
+  routes = [
+    {
+      remote_subnet = "10.17.0.0/22"
+    },
+    {
+      remote_subnet = "10.16.80.0/24"
+    }
+  ]
 }

--- a/examples/single_tunnels/prod.tf
+++ b/examples/single_tunnels/prod.tf
@@ -25,7 +25,13 @@ module "vpn-gw-us-we1-prd-mgt-internal" {
   tunnel_count       = 1
   peer_ips           = [module.vpn-gw-us-we1-mgt-prd-internal.gateway_ip]
 
-  route_priority = 1000
-  remote_subnet  = ["10.17.32.0/20", "10.17.16.0/20"]
+  routes = [
+    {
+      remote_subnet = "10.17.0.0/22"
+    },
+    {
+      remote_subnet = "10.16.80.0/24"
+    }
+  ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -20,17 +20,17 @@ locals {
 }
 
 # For VPN gateways with static routing
-## Create Route (for static routing gateways)
+## Create Routes (for static routing gateways)
 resource "google_compute_route" "route" {
-  count      = !var.cr_enabled ? var.tunnel_count * length(var.remote_subnet) : 0
-  name       = "${google_compute_vpn_gateway.vpn_gateway.name}-tunnel${floor(count.index / length(var.remote_subnet)) + 1}-route${count.index % length(var.remote_subnet) + 1}"
+  count      = !var.cr_enabled ? var.tunnel_count * length(var.routes) : 0
+  name       = "${google_compute_vpn_gateway.vpn_gateway.name}-tunnel${floor(count.index / length(var.routes)) + 1}-route${count.index % length(var.routes) + 1}"
   network    = var.network
   project    = var.project_id
-  dest_range = var.remote_subnet[count.index % length(var.remote_subnet)]
-  priority   = var.route_priority
-  tags       = var.route_tags
+  dest_range = var.routes[count.index % length(var.routes)].remote_subnet
+  priority   = var.routes[count.index % length(var.routes)].priority
+  tags       = var.routes[count.index % length(var.routes)].tags
 
-  next_hop_vpn_tunnel = google_compute_vpn_tunnel.tunnel-static[floor(count.index / length(var.remote_subnet))].self_link
+  next_hop_vpn_tunnel = google_compute_vpn_tunnel.tunnel-static[floor(count.index / length(var.routes))].self_link
 
   depends_on = [google_compute_vpn_tunnel.tunnel-static]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -74,21 +74,32 @@ variable "peer_ips" {
   description = "IP address of remote-peer/gateway"
 }
 
-variable "remote_subnet" {
-  description = "remote subnet ip range in CIDR format - x.x.x.x/x"
-  type        = list(string)
-  default     = []
+variable "routes" {
+  description = <<EOT
+    routes = {
+      remote_subnet : "remote subnet ip range in CIDR format - x.x.x.x/x"
+      priority : "Priority for the static route being created"
+      tags : "A list of instance tags to which this route applies."
+    }
+  EOT
+  type = list(object({
+    remote_subnet = string
+    priority      = number
+    tags          = list(string)
+  }))
+  default = [
+    {
+      remote_subnet = ""
+      priority      = 1000
+      tags          = []
+    }
+  ]
 }
 
 variable "shared_secret" {
   type        = string
   description = "Please enter the shared secret/pre-shared key"
   default     = ""
-}
-
-variable "route_priority" {
-  description = "Priority for static route being created"
-  default     = 1000
 }
 
 variable "cr_name" {
@@ -136,10 +147,4 @@ variable "vpn_gw_ip" {
   type        = string
   description = "Please enter the public IP address of the VPN Gateway, if you have already one. Do not set this variable to autocreate one"
   default     = ""
-}
-
-variable "route_tags" {
-  type        = list(string)
-  description = "A list of instance tags to which this route applies."
-  default     = []
 }


### PR DESCRIPTION
- Move route_priority, tags, and remote_subnet to a route object. This allows each remote_subnet to have a different route priority and/or tags.