### PR TITLE
add module_depends_on

### DIFF
--- a/gateway.tf
+++ b/gateway.tf
@@ -16,17 +16,24 @@
 
 # Static External IP for the VPN Gateway
 resource "google_compute_address" "vpn_gw_ip" {
-  count   = var.vpn_gw_ip == "" ? 1 : 0
-  name    = "ip-${var.gateway_name}"
-  region  = var.region
-  project = var.project_id
+  count      = var.vpn_gw_ip == "" ? 1 : 0
+  name       = "ip-${var.gateway_name}"
+  region     = var.region
+  project    = var.project_id
+  depends_on = [null_resource.module_depends_on]
 }
 
 # VPN Gateways
 resource "google_compute_vpn_gateway" "vpn_gateway" {
-  name    = var.gateway_name
-  network = var.network
-  region  = var.region
-  project = var.project_id
+  name       = var.gateway_name
+  network    = var.network
+  region     = var.region
+  project    = var.project_id
+  depends_on = [null_resource.module_depends_on]
 }
 
+resource "null_resource" "module_depends_on" {
+  triggers = {
+    value = length(var.module_depends_on)
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -145,3 +145,9 @@ variable "route_tags" {
   description = "A list of instance tags to which this route applies."
   default     = []
 }
+
+variable "module_depends_on" {
+  description = "List of modules or resources this module depends on."
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
the resources 

- google_compute_address.vpn_gw_ip
- google_compute_vpn_gateway.vpn_gateway

need the google_project_service resources for the project referenced by var.project_id to be already created

the changes in the pull request add the possibility to add these dependencies using the same principle as used in the submodule [network-peering](https://registry.terraform.io/modules/terraform-google-modules/network/google/latest/submodules/network-peering) of the module [network](https://registry.terraform.io/modules/terraform-google-modules/network/google/latest)