### PR TITLE
adding labels to VPN external gateway

### DIFF
--- a/modules/vpn_ha/main.tf
+++ b/modules/vpn_ha/main.tf
@@ -51,6 +51,7 @@ resource "google_compute_external_vpn_gateway" "external_gateway" {
   project         = var.project_id
   redundancy_type = var.peer_external_gateway.redundancy_type
   description     = "Terraform managed external VPN gateway"
+  labels          = var.labels
   dynamic "interface" {
     for_each = var.peer_external_gateway.interfaces
     content {


### PR DESCRIPTION
Only the VPN Tunnel labels were added in commit: https://github.com/terraform-google-modules/terraform-google-vpn/commit/c2e563b4d5cf6b907898fd56f287fcbbb72274b5

added missing labels for the VPN external gateway