### PR TITLE
feat: support multiple external VPN peering gateways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,8 @@ crash.log
 # version control.
 #
 # example.tfvars
-test/fixtures/shared/terraform.tfvars
+terraform.tfvars
+
 
 credentials.json
 

--- a/examples/multi_external_vpn_gateways/prod.tf
+++ b/examples/multi_external_vpn_gateways/prod.tf
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Creating an external VPN gateway IP for DC1
+resource "google_compute_external_vpn_gateway" "external_gateway1" {
+  provider        = google-beta
+  name            = "vpn-peering-gw1"
+  project         = var.prod_project_id
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "My VPN peering gateway1"
+
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+# Creating an external VPN gateway IP for DC2
+resource "google_compute_external_vpn_gateway" "external_gateway2" {
+  provider        = google-beta
+  name            = "vpn-peering-gw2"
+  project         = var.prod_project_id
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "My VPN peering gateway2"
+
+  interface {
+    id         = 0
+    ip_address = "8.4.4.8"
+  }
+}
+
+# In order to have successful setup, you need to configure the On-Premise
+# VPN by this below tunnels configuration.
+
+module "vpn-ha-to-onprem" {
+  source     = "../../modules/vpn_ha"
+  project_id = var.prod_project_id
+  region     = var.region
+  network    = var.prod_network_self_link
+  name       = "prod-to-onprem"
+  router_asn = 64512
+
+  tunnels = {
+    # DC1 remote tunnel with specific external VPN gateway
+    remote-0 = {
+      bgp_peer = {
+        address = "169.254.1.2"
+        asn     = 64515
+      }
+      bgp_peer_options                = null
+      bgp_session_range               = "169.254.1.1/30"
+      ike_version                     = 2
+      vpn_gateway_interface           = 0
+      peer_external_gateway_self_link = google_compute_external_vpn_gateway.external_gateway1.self_link
+      peer_external_gateway_interface = 0
+      shared_secret                   = "Secret1"
+    }
+
+    # DC2 remote tunnel with specific external VPN gateway
+    remote-1 = {
+      bgp_peer = {
+        address = "169.254.2.2"
+        asn     = 64516
+      }
+      bgp_peer_options                = null
+      bgp_session_range               = "169.254.2.1/30"
+      ike_version                     = 2
+      vpn_gateway_interface           = 1
+      peer_external_gateway_self_link = google_compute_external_vpn_gateway.external_gateway2.self_link
+      peer_external_gateway_interface = 0
+      shared_secret                   = "Secret2"
+    }
+  }
+}

--- a/examples/multi_external_vpn_gateways/variables.tf
+++ b/examples/multi_external_vpn_gateways/variables.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "prod_project_id" {
+  description = "Production Project ID."
+  type        = string
+}
+
+variable "prod_network_self_link" {
+  description = "Production Network Self Link."
+  type        = string
+}
+
+variable "region" {
+  description = "Region."
+  type        = string
+  default     = "europe-west4"
+}

--- a/examples/multi_external_vpn_gateways/versions.tf
+++ b/examples/multi_external_vpn_gateways/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 1.3"
+}

--- a/modules/vpn_ha/README.md
+++ b/modules/vpn_ha/README.md
@@ -236,7 +236,7 @@ module "vpn_ha" {
       bgp_session_name                = "bgp-peer-0"
       bgp_session_range               = "169.254.1.2/30"
       ike_version                     = 2
-      peer_external_gateway_self_link = google_compute_external_vpn_gateway.external_gateway1.self_link
+      peer_external_gateway_self_link = google_compute_external_vpn_gateway.external_gateway1.self_link # set a resource link
       peer_external_gateway_interface = 0
       vpn_gateway_interface           = 0
       shared_secret                   = "mySecret"
@@ -250,7 +250,7 @@ module "vpn_ha" {
       bgp_session_name                = "bgp-peer-1"
       bgp_session_range               = "169.254.2.2/30"
       ike_version                     = 2
-      peer_external_gateway_self_link = google_compute_external_vpn_gateway.external_gateway2.self_link
+      peer_external_gateway_self_link = google_compute_external_vpn_gateway.external_gateway2.self_link # set a resource link
       peer_external_gateway_interface = 0
       vpn_gateway_interface           = 1
       shared_secret                   = "mySecret"

--- a/modules/vpn_ha/README.md
+++ b/modules/vpn_ha/README.md
@@ -174,7 +174,7 @@ module "vpn_ha" {
         asn     = 64513
       }
       bgp_session_name                = "bgp-peer-1"
-      bgp_session_range               = "169.254.2.1/30"
+      bgp_session_range               = "169.254.2.2/30"
       ike_version                     = 2
       peer_external_gateway_interface = 0
       vpn_gateway_interface           = 1
@@ -248,7 +248,7 @@ module "vpn_ha" {
         asn     = 64513
       }
       bgp_session_name                = "bgp-peer-1"
-      bgp_session_range               = "169.254.2.1/30"
+      bgp_session_range               = "169.254.2.2/30"
       ike_version                     = 2
       peer_external_gateway_self_link = google_compute_external_vpn_gateway.external_gateway2.self_link
       peer_external_gateway_interface = 0

--- a/modules/vpn_ha/main.tf
+++ b/modules/vpn_ha/main.tf
@@ -25,7 +25,6 @@ locals {
     var.peer_external_gateway != null
     ? google_compute_external_vpn_gateway.external_gateway[0].self_link
     : null
-
   )
   secret = random_id.secret.b64_url
   vpn_gateway_self_link = (
@@ -169,7 +168,7 @@ resource "google_compute_vpn_tunnel" "tunnels" {
   region                          = var.region
   name                            = "${var.name}-${each.key}"
   router                          = local.router
-  peer_external_gateway           = local.peer_external_gateway
+  peer_external_gateway           = each.value.peer_external_gateway_self_link != null ? each.value.peer_external_gateway_self_link : local.peer_external_gateway
   peer_external_gateway_interface = each.value.peer_external_gateway_interface
   peer_gcp_gateway                = var.peer_gcp_gateway
   vpn_gateway_interface           = each.value.vpn_gateway_interface

--- a/modules/vpn_ha/variables.tf
+++ b/modules/vpn_ha/variables.tf
@@ -111,6 +111,7 @@ variable "tunnels" {
     bgp_session_range               = optional(string)
     ike_version                     = optional(number)
     vpn_gateway_interface           = optional(number)
+    peer_external_gateway_self_link = optional(string, null)
     peer_external_gateway_interface = optional(number)
     shared_secret                   = optional(string, "")
   }))


### PR DESCRIPTION
Hello,

we would like to add this feature because we see that we could have many VPN peering gateways on selected tunnels in the GCP console without any issue, but this Terraform module does not support that. 

In our case, we have an HA VPN that is connected to 2 on-premise DCs and instead of creating a new VPN instance, we may create a new tunnel that is linked to the specific peering gateway.

First, I thought to redo the variable of `peer_external_gateway` to set `list(object...`, but I realized it became very complicated from Terraform's point of view. So I added an optional element `peer_external_gateway_self_link` in the tunnels list object, so we could pass a custom resource `self_link` and set `var.peer_external_gateway` to `null` to prevent creating resource inside of the module.

Feedback is welcome.
Thank you, Donatas

