### PR TITLE
chore: upgraded versions.tf to include minor bumps from tpg v5

### DIFF
--- a/modules/vpn_ha/main.tf
+++ b/modules/vpn_ha/main.tf
@@ -61,17 +61,10 @@ resource "google_compute_external_vpn_gateway" "external_gateway" {
   }
 }
 
-data "google_compute_router" "router" {
-  name    = var.router_name == null ? "" : var.router_name
-  network = var.network
-  project = var.project_id
-  region  = var.region
-}
-
 resource "google_compute_router" "router" {
   provider = google-beta
-  count    = data.google_compute_router.router.name == null ? 1 : 0
-  name     = var.router_name != "" ? var.router_name : "vpn-${var.name}"
+  count    = var.router_name == "" ? 1 : 0
+  name     = "vpn-${var.name}"
   project  = var.project_id
   region   = var.region
   network  = var.network

--- a/modules/vpn_ha/versions.tf
+++ b/modules/vpn_ha/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.74, < 5.0"
+      version = ">= 4.74, < 6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.74, < 5.0"
+      version = ">= 4.74, < 6"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.30.0, < 5.0"
+      version = ">= 3.30.0, < 6"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This also remove the data block from the vpn_ha module used to lookup if a router already existed. With TGP v5, that block returns a 404 if the router doesn't exist causing the plan to fail. Based on this change, if a user wants to use an existing router, they should import it before running the plan.