### PR TITLE
fix: Add lifecycle to prevent changes when shared secret is updated

### DIFF
--- a/modules/vpn_ha/main.tf
+++ b/modules/vpn_ha/main.tf
@@ -164,6 +164,10 @@ resource "google_compute_vpn_tunnel" "tunnels" {
   shared_secret                   = each.value.shared_secret == "" ? local.secret : each.value.shared_secret
   vpn_gateway                     = local.vpn_gateway_self_link
   labels                          = var.labels
+  
+  lifecycle {
+    ignore_changes = [shared_secret]
+  }
 }
 
 resource "random_id" "secret" {


### PR DESCRIPTION
Add lifecycle to the VPN in order to prevent VPN replacement due to shared secrets being pulled by data resource from GCP Secrets Manager

 <= data "google_secret_manager_secret_version" xxx" {
      + create_time  = (known after apply)
      + destroy_time = (known after apply)
      + enabled      = (known after apply)
      + id           = (known after apply)
      + name         = (known after apply)
      + secret_data  = (sensitive value)
      + version      = (known after apply)
    }

-/+ resource "google_compute_vpn_tunnel" "tunnels" {
      ~ creation_timestamp              = "2022-05-03T00:23:06.875-07:00" -> (known after apply)
      ~ detailed_status                 = "Tunnel is up and running." -> (known after apply)
      ~ label_fingerprint               = "gYs4vEHLW2w=" -> (known after apply)
      ~ local_traffic_selector          = [
          - "0.0.0.0/0",
        ] -> (known after apply)
      - peer_external_gateway_interface = 0 -> null
      ~ remote_traffic_selector         = [
          - "0.0.0.0/0",
        ] -> (known after apply)
      ~ shared_secret                   = (sensitive value) # forces replacement

    }