### PR TITLE
feat: Making IPSEC PSK length configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ References the variable descriptions below to determine the right configuration.
 | cr\_name | The name of cloud router for BGP routing | `string` | `""` | no |
 | gateway\_name | The name of VPN gateway | `string` | `"test-vpn"` | no |
 | ike\_version | Please enter the IKE version used by this tunnel (default is IKEv2) | `number` | `2` | no |
+| ipsec\_secret\_length | The lnegth the of shared secret for VPN tunnels | `number` | `8` | no |
 | local\_traffic\_selector | Local traffic selector to use when establishing the VPN tunnel with peer VPN gateway.<br>Value should be list of CIDR formatted strings and ranges should be disjoint. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | network | The name of VPC being created | `string` | n/a | yes |
 | peer\_asn | Please enter the ASN of the BGP peer that cloud router will use | `list(string)` | <pre>[<br>  "65101"<br>]</pre> | no |

--- a/modules/vpn_ha/README.md
+++ b/modules/vpn_ha/README.md
@@ -268,6 +268,7 @@ module "vpn_ha" {
 |------|-------------|------|---------|:--------:|
 | create\_vpn\_gateway | create a VPN gateway | `bool` | `true` | no |
 | external\_vpn\_gateway\_description | An optional description of external VPN Gateway | `string` | `"Terraform managed external VPN gateway"` | no |
+| ipsec\_secret\_length | The lnegth the of shared secret for VPN tunnels | `number` | `8` | no |
 | keepalive\_interval | The interval in seconds between BGP keepalive messages that are sent to the peer. | `number` | `20` | no |
 | labels | Labels for vpn components | `map(string)` | `{}` | no |
 | name | VPN gateway name, and prefix used for dependent resources. | `string` | n/a | yes |

--- a/modules/vpn_ha/main.tf
+++ b/modules/vpn_ha/main.tf
@@ -167,5 +167,5 @@ resource "google_compute_vpn_tunnel" "tunnels" {
 }
 
 resource "random_id" "secret" {
-  byte_length = 8
+  byte_length = var.ipsec_secret_length
 }

--- a/modules/vpn_ha/variables.tf
+++ b/modules/vpn_ha/variables.tf
@@ -141,3 +141,9 @@ variable "external_vpn_gateway_description" {
   type        = string
   default     = "Terraform managed external VPN gateway"
 }
+
+variable "ipsec_secret_length" {
+  type        = number
+  description = "The lnegth the of shared secret for VPN tunnels"
+  default     = 8
+}

--- a/tunnel.tf
+++ b/tunnel.tf
@@ -16,7 +16,7 @@
 
 # Creating the VPN tunnel
 resource "random_id" "ipsec_secret" {
-  byte_length = 8
+  byte_length = var.ipsec_secret_length
 }
 
 resource "google_compute_vpn_tunnel" "tunnel-static" {

--- a/variables.tf
+++ b/variables.tf
@@ -145,3 +145,9 @@ variable "route_tags" {
   description = "A list of instance tags to which this route applies."
   default     = []
 }
+
+variable "ipsec_secret_length" {
+  type        = number
+  description = "The lnegth the of shared secret for VPN tunnels"
+  default     = 8
+}


### PR DESCRIPTION
IPSEC PSK secret is hardcoded to length 8 which is not sufficient in production and may want longer secret. So raising this PR to make the length configurable. I've run the lint test. Attached is the screenshot.

![image](https://github.com/user-attachments/assets/b7a36e88-23f6-4c49-adf0-4784682c8cc2)
