### PR TITLE
feat: add support for HA VPN over interconnect

### DIFF
--- a/modules/vpn_ha/README.md
+++ b/modules/vpn_ha/README.md
@@ -268,6 +268,7 @@ module "vpn_ha" {
 |------|-------------|------|---------|:--------:|
 | create\_vpn\_gateway | create a VPN gateway | `bool` | `true` | no |
 | external\_vpn\_gateway\_description | An optional description of external VPN Gateway | `string` | `"Terraform managed external VPN gateway"` | no |
+| interconnect\_attachment | URL of the interconnect attachment resource. When the value of this field is present, the VPN Gateway will be used for IPsec-encrypted Cloud Interconnect. | `list(string)` | `[]` | no |
 | ipsec\_secret\_length | The lnegth the of shared secret for VPN tunnels | `number` | `8` | no |
 | keepalive\_interval | The interval in seconds between BGP keepalive messages that are sent to the peer. | `number` | `20` | no |
 | labels | Labels for vpn components | `map(string)` | `{}` | no |

--- a/modules/vpn_ha/main.tf
+++ b/modules/vpn_ha/main.tf
@@ -42,6 +42,13 @@ resource "google_compute_ha_vpn_gateway" "ha_gateway" {
   network    = var.network
   stack_type = var.stack_type
   labels     = var.labels
+  dynamic "vpn_interfaces" {
+    for_each = { for idx, val in var.interconnect_attachment : idx => val }
+    content {
+      id                      = vpn_interfaces.key
+      interconnect_attachment = vpn_interfaces.value
+    }
+  }
 }
 
 resource "google_compute_external_vpn_gateway" "external_gateway" {

--- a/modules/vpn_ha/variables.tf
+++ b/modules/vpn_ha/variables.tf
@@ -44,6 +44,12 @@ variable "stack_type" {
   default     = "IPV4_ONLY"
 }
 
+variable "interconnect_attachment" {
+  description = "URL of the interconnect attachment resource. When the value of this field is present, the VPN Gateway will be used for IPsec-encrypted Cloud Interconnect."
+  type        = list(string)
+  default     = []
+}
+
 variable "network" {
   description = "VPC used for the gateway and routes."
   type        = string


### PR DESCRIPTION
This PR is to add HA VPN over interconnect support.

respective resource example: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ha_vpn_gateway#example-usage---compute-ha-vpn-gateway-encrypted-interconnect
 
deployment pattern: https://cloud.google.com/network-connectivity/docs/interconnect/concepts/ha-vpn-interconnect

I have made companion PR to https://github.com/terraform-google-modules/terraform-google-cloud-router/pull/142 as well.