### PR TITLE
feat!: replace bgp_peer when updating router_interface bgp_session_range

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,5 +62,11 @@ resource "google_compute_router_peer" "bgp_peer" {
   project                   = var.project_id
 
   depends_on = [google_compute_router_interface.router_interface]
+
+  lifecycle {
+    replace_triggered_by = [
+      google_compute_router_interface.router_interface[0].ip_range
+    ]
+  }
 }
 

--- a/modules/vpn_ha/main.tf
+++ b/modules/vpn_ha/main.tf
@@ -153,6 +153,12 @@ resource "google_compute_router_peer" "bgp_peer" {
     }
   }
   interface = google_compute_router_interface.router_interface[each.key].name
+
+  lifecycle {
+    replace_triggered_by = [
+      google_compute_router_interface.router_interface[each.key].ip_range
+    ]
+  }
 }
 
 resource "google_compute_router_interface" "router_interface" {


### PR DESCRIPTION
Close #204 

Currently it's impossible to change BGP session range and BGP peer IP of a tunnel without have to manually taint the related google_compute_router_peer.bgp_peer, because the creation of new `google_compute_router_interface.router_interface` will be block because of Invalid value for field 'resource.bgpPeers[1].ipAddress' that is managed by `google_compute_router_peer.bgp_peer` (as explained in #204).

This PR will force replacement for `google_compute_router_peer.bgp_peer` for any tunnel when changing BGP session range of the same tunnel, so it won't block the recreation of `google_compute_router_interface.router_interface`.

